### PR TITLE
Accelerate rep-reading using GPU

### DIFF
--- a/repe/rep_readers.py
+++ b/repe/rep_readers.py
@@ -7,6 +7,7 @@ from itertools import islice
 import torch
 # ### Util Functions ###
 def _epoch(layer, hidden_states, mean, direction,component_index, transformed_hidden_states):
+    '''Failed multi-processing attempt'''
     layer_hidden_states = hidden_states[layer]
     layer_hidden_states = recenter(layer_hidden_states, mean=mean[layer])
     # project hidden states onto found concept directions (e.g. onto PCA comp 0) 
@@ -46,12 +47,6 @@ def recenter(x, mean=None):
         mean = torch.mean(x,axis=0,keepdims=True)
     else:
         mean = torch.Tensor(mean).cuda()
-    # print(type(x), type(mean))
-        # mean = x.mean(axis=0, keepdims=True)
-        mean = torch.mean(x,axis=0,keepdims=True)
-    else:
-        mean = torch.Tensor(mean).cuda()
-    # print(type(x), type(mean))
     return x - mean
 
 class RepReader(ABC):

--- a/repe/rep_readers.py
+++ b/repe/rep_readers.py
@@ -4,17 +4,38 @@ from sklearn.cluster import KMeans
 import numpy as np
 from itertools import islice
 
-### Util Functions ###
+import torch
+# ### Util Functions ###
+def _epoch(layer, hidden_states, mean, direction,component_index, transformed_hidden_states):
+    layer_hidden_states = hidden_states[layer]
+    layer_hidden_states = recenter(layer_hidden_states, mean=mean[layer])
+    # project hidden states onto found concept directions (e.g. onto PCA comp 0) 
+    H_transformed = project_onto_direction(layer_hidden_states, direction[layer][component_index])
+    transformed_hidden_states[layer] = H_transformed.cpu().numpy()
+
+
+
 def project_onto_direction(H, direction):
     """Project matrix H (n, d_1) onto direction vector (d_2,)"""
-    # TODO: should we require direction vectors to be unit vectors? then return H.dot(direction)
-    mag = np.linalg.norm(direction)
-    assert not np.isinf(mag)
-    return H.dot(direction) / mag
+    # Calculate the magnitude of the direction vector
+     # Ensure H and direction are on the same device (CPU or GPU)
+    device = H.device
+    if type(direction) != torch.Tensor:
+        direction = torch.Tensor(direction)
+    direction = direction.to(device)
+    mag = torch.norm(direction)
+    assert not torch.isinf(mag).any()
+    # Calculate the projection
+    projection = H.matmul(direction) / mag
+    return projection
 
 def recenter(x, mean=None):
     if mean is None:
-        mean = x.mean(axis=0, keepdims=True)
+        # mean = x.mean(axis=0, keepdims=True)
+        mean = torch.mean(x,axis=0,keepdims=True)
+    else:
+        mean = torch.Tensor(mean).cuda()
+    # print(type(x), type(mean))
     return x - mean
 
 class RepReader(ABC):
@@ -102,7 +123,8 @@ class RepReader(ABC):
         """
 
         assert component_index < self.n_components
-
+        import time
+        t1 = time.time()
         transformed_hidden_states = {}
         for layer in hidden_layers:
             layer_hidden_states = hidden_states[layer]
@@ -112,9 +134,15 @@ class RepReader(ABC):
 
             # project hidden states onto found concept directions (e.g. onto PCA comp 0) 
             H_transformed = project_onto_direction(layer_hidden_states, self.directions[layer][component_index])
-            transformed_hidden_states[layer] = H_transformed
+            transformed_hidden_states[layer] = H_transformed.cpu().numpy()
 
+        t2 = time.time()
+        
         return transformed_hidden_states
+    
+
+    def load(self, d, s):
+        self.directions, self.direction_signs = d, s
 
 class PCARepReader(RepReader):
     """Extract directions via PCA"""
@@ -175,6 +203,18 @@ class PCARepReader(RepReader):
 
         return signs
     
+    def save(self):
+        import pickle
+        with open('/public/home/llm2/representation-engineering/examples/honesty/honesty_para/honesty.pkl', 'wb') as file:
+            pickle.dump((self.directions, self.direction_signs, self.direction_method, self.H_train_means), file)
+    
+
+    def load(self, d, s, h):
+        super().load(d, s)
+        self.H_train_means = h
+
+
+        
 class ClusterMeanRepReader(RepReader):
     """Get the direction that is the difference between the mean of the positive and negative clusters."""
     n_components = 1

--- a/repe/rep_reading_pipeline.py
+++ b/repe/rep_reading_pipeline.py
@@ -23,7 +23,8 @@ class RepReadingPipeline(Pipeline):
         for layer in hidden_layers:
             hidden_states = outputs['hidden_states'][layer]
             hidden_states =  hidden_states[:, rep_token, :]
-            hidden_states_layers[layer] = hidden_states.cpu().to(dtype=torch.float32).detach().numpy()
+            # hidden_states_layers[layer] = hidden_states.cpu().to(dtype=torch.float32).detach().numpy()
+            hidden_states_layers[layer] = hidden_states.detach()
 
         return hidden_states_layers
 

--- a/repe/rep_reading_pipeline.py
+++ b/repe/rep_reading_pipeline.py
@@ -94,7 +94,7 @@ class RepReadingPipeline(Pipeline):
         for hidden_states_batch in hidden_states_outputs:
             for layer in hidden_states_batch:
                 hidden_states[layer].extend(hidden_states_batch[layer])
-        return {k: np.array(v) for k, v in hidden_states.items()}
+        return {k: np.vstack(v) for k, v in hidden_states.items()}
     
     def _validate_params(self, n_difference, direction_method):
         # validate params for get_directions


### PR DESCRIPTION
1. The computation of the rep-reading pipeline is super slow and the bottleneck lies in the ```repe_reader.transform``` blocks. We send the matrix-intensive computation to GPUs using ```torch```.
2. The computation of  ```get_direction``` is super slow because of the PCA on the CPU, we set up a save-load pattern to compute it once for a dataset. It is better to run PCA on Cuda.
3.  Also, we try to optimize the layer-wise computation in ```pipeline._forward``` by using the multi-processing but it fails to accelerate so we delete it.